### PR TITLE
Fix https proxy and build

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v0.0.5]
+
+- Fix https proxy requests.
+
 ## [v0.0.4](https://github.com/ontola/koa-http2-proxy/releases/tag/v0.0.4)
 
 - handle errors caused by socket.destroy();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "koa-http2-proxy",
-  "version": "0.0.5",
+  "name": "@hvdb/koa-http2-proxy",
+  "version": "0.0.6",
   "description": "Configure http2-proxy middleware with ease for koa.",
   "main": "dist/index.js",
   "files": [
@@ -24,7 +24,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/ontola/koa-http2-proxy.git"
+    "url": "https://github.com/hvdb/koa-http2-proxy.git"
   },
   "keywords": [
     "reverse",
@@ -41,9 +41,9 @@
   "author": "Steven Chim, Ontola BV",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/ontola/koa-http2-proxy/issues"
+    "url": "https://github.com/hvdb/koa-http2-proxy/issues"
   },
-  "homepage": "https://github.com/ontola/koa-http2-proxy",
+  "homepage": "https://github.com/hvdb/koa-http2-proxy",
   "devDependencies": {
     "@commitlint/cli": "^8.0.0",
     "@commitlint/config-conventional": "^8.0.0",
@@ -87,5 +87,9 @@
     "extends": [
       "@commitlint/config-conventional"
     ]
+  },
+  "publishConfig": {
+    "registry": "https://registry.npmjs.org/",
+    "access": "public"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "koa-http2-proxy",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "Configure http2-proxy middleware with ease for koa.",
   "main": "dist/index.js",
   "files": [


### PR DESCRIPTION
When proxy request was https it failed because the http module was used for the request.

Added a small switch to use the correct http(s) module based on the protocol needed.